### PR TITLE
New DockerRegistryClient.repository() method

### DIFF
--- a/docker_registry_client/DockerRegistryClient.py
+++ b/docker_registry_client/DockerRegistryClient.py
@@ -14,6 +14,14 @@ class DockerRegistryClient(object):
     def namespaces(self):
         return list(self._repositories_by_namespace.keys())
 
+    def repository(self, repository, namespace=None):
+        if '/' in repository:
+            if namespace is not None:
+                raise RuntimeError('cannot specify namespace twice')
+            namespace, repository = repository.split('/', 1)
+
+        return Repository(self._base_client, repository, namespace=namespace)
+
     def repositories(self, namespace=None):
         if namespace:
             return self._repositories_by_namespace[namespace]

--- a/tests/test_dockerregistryclient.py
+++ b/tests/test_dockerregistryclient.py
@@ -17,6 +17,26 @@ class TestDockerRegistryClient(object):
         client = DockerRegistryClient(url)
         assert client.namespaces() == [TEST_NAMESPACE]
 
+    @pytest.mark.parametrize('version', [1, 2])
+    @pytest.mark.parametrize(('repository', 'namespace'), [
+        (TEST_REPO, None),
+        (TEST_REPO, TEST_NAMESPACE),
+        ('{0}/{1}'.format(TEST_NAMESPACE, TEST_REPO), None),
+    ])
+    def test_repository(self, version, repository, namespace):
+        url = mock_registry(version)
+        client = DockerRegistryClient(url)
+        repository = client.repository(repository, namespace=namespace)
+        assert isinstance(repository, MockRegistry)
+
+    @pytest.mark.parametrize('version', [1, 2])
+    def test_repository(self, version):
+        url = mock_registry(version)
+        client = DockerRegistryClient(url)
+        with pytest.raises(RuntimeError):
+            client.repository('{0}/{1}'.format(TEST_NAMESPACE, TEST_REPO),
+                              namespace=TEST_NAMESPACE)
+
     @pytest.mark.parametrize('namespace', [TEST_NAMESPACE, None])
     @pytest.mark.parametrize('version', [1, 2])
     def test_repositories(self, version, namespace):


### PR DESCRIPTION
This allows fetching a single repository even when search/catalog is not supported.