### PR TITLE
Add --api-version parameter to example tool

### DIFF
--- a/docker-registry-show.py
+++ b/docker-registry-show.py
@@ -34,12 +34,13 @@ class CLI(object):
                                  action='store_true')
         self.parser.add_argument('--no-verify-ssl', dest='verify_ssl',
                                  action='store_false')
+        self.parser.add_argument('--api-version', metavar='VER', type=int)
 
         self.parser.add_argument('registry', metavar='REGISTRY', nargs=1,
                                  help='registry URL (including scheme)')
         self.parser.add_argument('repository', metavar='REPOSITORY', nargs='?')
 
-        self.parser.set_defaults(verify_ssl=True)
+        self.parser.set_defaults(verify_ssl=True, api_version=None)
 
     def run(self):
         args = self.parser.parse_args()
@@ -52,8 +53,13 @@ class CLI(object):
 
         logging.basicConfig(**basic_config_args)
 
+        kwargs = {}
+        if args.api_version:
+            kwargs['api_version'] = args.api_version
+
         client = DockerRegistryClient(args.registry[0],
-                                      verify_ssl=args.verify_ssl)
+                                      verify_ssl=args.verify_ssl,
+                                      **kwargs)
 
         if args.repository:
             self.show_tags(client, args.repository)

--- a/docker_registry_client/Image.py
+++ b/docker_registry_client/Image.py
@@ -17,7 +17,7 @@ class ImageV1(object):
         return self.get_json()[field]
 
     def put_json(self, data):
-        #return self._client.put_image_layer(self.image_id, data)
+        # return self._client.put_image_layer(self.image_id, data)
         raise NotImplementedError()
 
     def ancestry(self):

--- a/docker_registry_client/__init__.py
+++ b/docker_registry_client/__init__.py
@@ -1,3 +1,5 @@
+# flake8: noqa
+
 from __future__ import absolute_import
 
 from docker_registry_client.DockerRegistryClient import (DockerRegistryClient,

--- a/tests/mock_registry.py
+++ b/tests/mock_registry.py
@@ -12,7 +12,8 @@ TEST_NAMESPACE = 'library'
 TEST_REPO = 'myrepo'
 TEST_NAME = '%s/%s' % (TEST_NAMESPACE, TEST_REPO)
 TEST_TAG = 'latest'
-TEST_MANIFEST_DIGEST = 'sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b'
+TEST_MANIFEST_DIGEST = '''\
+sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b'''
 
 
 class MockResponse(object):

--- a/tests/test_dockerregistryclient.py
+++ b/tests/test_dockerregistryclient.py
@@ -86,3 +86,4 @@ class TestDockerRegistryClient(object):
             with pytest.raises(HTTPError):
                 client = DockerRegistryClient(url,
                                               api_version=client_api_version)
+                client.refresh()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,6 @@
 import docker_registry_client
 
+
 def test_exported_symbols():
     assert hasattr(docker_registry_client, 'DockerRegistryClient')
     assert hasattr(docker_registry_client, 'BaseClient')

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -12,9 +12,8 @@ from tests.mock_registry import (mock_v1_registry,
 class TestRepository(object):
     def test_initv1(self):
         url = mock_v1_registry()
-        repo = Repository(BaseClientV1(url), TEST_REPO,
-                          namespace=TEST_NAMESPACE)
+        Repository(BaseClientV1(url), TEST_REPO, namespace=TEST_NAMESPACE)
 
     def test_initv2(self):
         url = mock_v2_registry()
-        repo = Repository(BaseClientV2(url), TEST_NAME)
+        Repository(BaseClientV2(url), TEST_NAME)


### PR DESCRIPTION
This PR fixes the test case for the `api_version` parameter (which had been written prior to lazy searching) cleans up some issues reported by the flake8 tool, and finally adds the optional parameter `--api-version VER` to the example `docker-registry-show.py` tool.