### PR TITLE
New DockerRegistryClient.api_version instance variable

### DIFF
--- a/docker_registry_client/DockerRegistryClient.py
+++ b/docker_registry_client/DockerRegistryClient.py
@@ -16,6 +16,7 @@ class DockerRegistryClient(object):
 
         self._base_client = BaseClient(host, verify_ssl=verify_ssl,
                                        api_version=api_version)
+        self.api_version = self._base_client.version
         self._repositories = {}
         self._repositories_by_namespace = {}
 

--- a/tests/test_dockerregistryclient.py
+++ b/tests/test_dockerregistryclient.py
@@ -14,6 +14,12 @@ from tests.mock_registry import (mock_registry,
 
 class TestDockerRegistryClient(object):
     @pytest.mark.parametrize('version', [1, 2])
+    def test_api_version_in_use(self, version):
+        url = mock_registry(version)
+        client = DockerRegistryClient(url)
+        assert client.api_version == version
+
+    @pytest.mark.parametrize('version', [1, 2])
     def test_namespaces(self, version):
         url = mock_registry(version)
         client = DockerRegistryClient(url)
@@ -81,7 +87,7 @@ class TestDockerRegistryClient(object):
         url = mock_registry(registry_api_version)
         if should_succeed:
             client = DockerRegistryClient(url, api_version=client_api_version)
-            assert client._base_client.version == client_api_version
+            assert client.api_version == client_api_version
         else:
             with pytest.raises(HTTPError):
                 client = DockerRegistryClient(url,


### PR DESCRIPTION
This is required so that callers know how to deal with the repository object, as they have different interfaces.