### PR TITLE
Added support for HTTP basic authentication (username+password)

### DIFF
--- a/docker_registry_client/DockerRegistryClient.py
+++ b/docker_registry_client/DockerRegistryClient.py
@@ -5,17 +5,20 @@ from docker_registry_client.Repository import Repository
 
 
 class DockerRegistryClient(object):
-    def __init__(self, host, verify_ssl=None, api_version=None):
+    def __init__(self, host, verify_ssl=None, api_version=None, username=None, password=None):
         """
         Constructor
 
         :param host: str, registry URL including scheme
         :param verify_ssl: bool, whether to verify SSL certificate
         :param api_version: int, API version to require
+        :param username: username to use for basic authentication when connecting to the registry
+        :param password: password to use for basic authentication
         """
 
         self._base_client = BaseClient(host, verify_ssl=verify_ssl,
-                                       api_version=api_version)
+                                       api_version=api_version,
+                                       username=username, password=password)
         self.api_version = self._base_client.version
         self._repositories = {}
         self._repositories_by_namespace = {}


### PR DESCRIPTION
Support for HTTP Basic authentication added using two optional parameters (username and password) to the client constructor. It is not possible to connect against an authentication-protected registry without this change.