### PR TITLE
Enh: Add accept field in header for v2 to ensure we have v2 images (u…

### DIFF
--- a/docker_registry_client/_BaseClient.py
+++ b/docker_registry_client/_BaseClient.py
@@ -198,7 +198,8 @@ class BaseClientV2(CommonBaseClient):
            kwargs -> url formatting args
         """
 
-        header = {'content-type': 'application/json'}
+        header = {'content-type': 'application/json',
+                  'Accept': 'application/vnd.docker.distribution.manifest.v2+json'}
 
         # Token specific part. We add the token in the header if necessary
         if self.auth.token_required:


### PR DESCRIPTION
…seful for deletion)

This header will tell the registry (version > 2.3) to return v2 manifest. This is necessary when deleting images in such versions. 

See : https://github.com/docker/distribution/blob/master/docs/spec/api.md#deleting-an-image

