### PR TITLE
Fix for "AttributeError: 'list' object has no attribute 'keys'" error

### DIFF
--- a/docker_registry_client/DockerRegistryClient.py
+++ b/docker_registry_client/DockerRegistryClient.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
-from docker_registry_client._BaseClient import BaseClient
-from docker_registry_client.Repository import Repository
+from ._BaseClient import BaseClient
+from .Repository import Repository
 
 
 class DockerRegistryClient(object):

--- a/docker_registry_client/Repository.py
+++ b/docker_registry_client/Repository.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from docker_registry_client.Image import Image
+from .Image import Image
 
 
 class BaseRepository(object):

--- a/docker_registry_client/Repository.py
+++ b/docker_registry_client/Repository.py
@@ -36,7 +36,10 @@ class RepositoryV1(BaseRepository):
         if self._images is None:
             self.refresh()
 
-        return list(self._images.keys())
+        if type(self._images) is list:
+            return list(taginfo['name'] for taginfo in self._images)
+        else:
+            return list(self._images.keys())
 
     def data(self, tag):
         return self._client.get_tag_json(self.namespace, self.repository, tag)

--- a/docker_registry_client/_BaseClient.py
+++ b/docker_registry_client/_BaseClient.py
@@ -2,7 +2,7 @@ import logging
 from requests import get, put, delete
 from requests.exceptions import HTTPError
 import json
-from docker_registry_client.AuthorizationService import AuthorizationService
+from .AuthorizationService import AuthorizationService
 from .manifest import sign as sign_manifest
 
 # urllib3 throws some ssl warnings with older versions of python

--- a/docker_registry_client/__init__.py
+++ b/docker_registry_client/__init__.py
@@ -2,6 +2,4 @@
 
 from __future__ import absolute_import
 
-from docker_registry_client.DockerRegistryClient import (DockerRegistryClient,
-                                                         BaseClient,
-                                                         Repository)
+from .DockerRegistryClient import (DockerRegistryClient, BaseClient, Repository)


### PR DESCRIPTION
At this moment, when you call `.tags()` - you'll get error:

```python
Traceback (most recent call last):
  File "test-docker.py", line 154, in <module>
    repo.tags()
  File "lib/dockerregistryclient/docker_registry_client/Repository.py", line 42, in tags
    return list(self._images.keys())
AttributeError: 'list' object has no attribute 'keys'
```

So `self._images` is list of dictionaries and has no `keys()` method.

Tested on python 3.5.2 and `api_version=1`.