### PR TITLE
Adding timeouts to all remote requests

### DIFF
--- a/docker_registry_client/AuthorizationService.py
+++ b/docker_registry_client/AuthorizationService.py
@@ -19,7 +19,7 @@ class AuthorizationService(object):
     authenticate to the registry. Token has to be renew each time we change
     "scope".
     """
-    def __init__(self, registry, url="", auth=None, verify=False):
+    def __init__(self, registry, url="", auth=None, verify=False, api_timeout=None):
         # Registry ip:port
         self.registry = urlsplit(registry).netloc
         # Service url, ip:port
@@ -27,6 +27,8 @@ class AuthorizationService(object):
         # Authentication (user, password) or None. Used by request to do
         # basicauth
         self.auth = auth
+        # Timeout for HTTP request
+        self.api_timeout = api_timeout
 
         # Desired scope is the scope needed for the next operation on the
         # registry
@@ -53,7 +55,7 @@ class AuthorizationService(object):
     def get_new_token(self):
         rsp = requests.get("%s/v2/token?service=%s&scope=%s" %
                            (self.url, self.registry, self.desired_scope),
-                           auth=self.auth, verify=self.verify)
+                           auth=self.auth, verify=self.verify, timeout=self.api_timeout)
         if not rsp.ok:
             logger.error("Can't get token for authentication")
             self.token = ""

--- a/docker_registry_client/AuthorizationService.py
+++ b/docker_registry_client/AuthorizationService.py
@@ -19,7 +19,8 @@ class AuthorizationService(object):
     authenticate to the registry. Token has to be renew each time we change
     "scope".
     """
-    def __init__(self, registry, url="", auth=None, verify=False, api_timeout=None):
+    def __init__(self, registry, url="", auth=None, verify=False,
+                 api_timeout=None):
         # Registry ip:port
         self.registry = urlsplit(registry).netloc
         # Service url, ip:port
@@ -55,7 +56,8 @@ class AuthorizationService(object):
     def get_new_token(self):
         rsp = requests.get("%s/v2/token?service=%s&scope=%s" %
                            (self.url, self.registry, self.desired_scope),
-                           auth=self.auth, verify=self.verify, timeout=self.api_timeout)
+                           auth=self.auth, verify=self.verify,
+                           timeout=self.api_timeout)
         if not rsp.ok:
             logger.error("Can't get token for authentication")
             self.token = ""

--- a/docker_registry_client/DockerRegistryClient.py
+++ b/docker_registry_client/DockerRegistryClient.py
@@ -6,7 +6,7 @@ from .Repository import Repository
 
 class DockerRegistryClient(object):
     def __init__(self, host, verify_ssl=None, api_version=None, username=None,
-                 password=None, auth_service_url=""):
+                 password=None, auth_service_url="", api_timeout=None):
         """
         Constructor
 
@@ -18,12 +18,14 @@ class DockerRegistryClient(object):
         :param password: password to use for basic authentication
         :param auth_service_url: authorization service URL (including scheme,
           for v2 only)
+        :param api_timeout: timeout for external request
         """
 
         self._base_client = BaseClient(host, verify_ssl=verify_ssl,
                                        api_version=api_version,
                                        username=username, password=password,
-                                       auth_service_url=auth_service_url)
+                                       auth_service_url=auth_service_url,
+                                       api_timeout=api_timeout)
         self.api_version = self._base_client.version
         self._repositories = {}
         self._repositories_by_namespace = {}

--- a/docker_registry_client/_BaseClient.py
+++ b/docker_registry_client/_BaseClient.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class CommonBaseClient(object):
-    def __init__(self, host, verify_ssl=None, username=None, password=None):
+    def __init__(self, host, verify_ssl=None, username=None, password=None, api_timeout=None):
         self.host = host
 
         self.method_kwargs = {}
@@ -23,6 +23,8 @@ class CommonBaseClient(object):
             self.method_kwargs['verify'] = verify_ssl
         if username is not None and password is not None:
             self.method_kwargs['auth'] = (username, password)
+        if api_timeout is not None:
+            self.method_kwargs['timeout'] = api_timeout
 
     def _http_response(self, url, method, data=None, **kwargs):
         """url -> full target url
@@ -157,6 +159,7 @@ class BaseClientV2(CommonBaseClient):
             url=auth_service_url,
             verify=self.method_kwargs.get('verify', False),
             auth=self.method_kwargs.get('auth', None),
+            api_timeout=self.method_kwargs.get('api_timeout')
         )
 
     @property
@@ -266,21 +269,21 @@ class BaseClientV2(CommonBaseClient):
 
 
 def BaseClient(host, verify_ssl=None, api_version=None, username=None,
-               password=None, auth_service_url=""):
+               password=None, auth_service_url="", api_timeout=None):
     if api_version == 1:
         return BaseClientV1(
-            host, verify_ssl=verify_ssl, username=username, password=password,
+            host, verify_ssl=verify_ssl, username=username, password=password, api_timeout=api_timeout,
         )
     elif api_version == 2:
         return BaseClientV2(
-            host, verify_ssl=verify_ssl, username=username, password=password,
+            host, verify_ssl=verify_ssl, username=username, password=password, api_timeout=api_timeout,
             auth_service_url=auth_service_url,
         )
     elif api_version is None:
         # Try V2 first
         logger.debug("checking for v2 API")
         v2_client = BaseClientV2(
-            host, verify_ssl=verify_ssl, username=username, password=password,
+            host, verify_ssl=verify_ssl, username=username, password=password, api_timeout=api_timeout,
             auth_service_url=auth_service_url,
         )
         try:
@@ -290,7 +293,7 @@ def BaseClient(host, verify_ssl=None, api_version=None, username=None,
                 logger.debug("falling back to v1 API")
                 return BaseClientV1(
                     host, verify_ssl=verify_ssl, username=username,
-                    password=password,
+                    password=password, api_timeout=api_timeout,
                 )
 
             raise

--- a/docker_registry_client/_BaseClient.py
+++ b/docker_registry_client/_BaseClient.py
@@ -15,7 +15,8 @@ logger = logging.getLogger(__name__)
 
 
 class CommonBaseClient(object):
-    def __init__(self, host, verify_ssl=None, username=None, password=None, api_timeout=None):
+    def __init__(self, host, verify_ssl=None, username=None, password=None,
+                 api_timeout=None):
         self.host = host
 
         self.method_kwargs = {}
@@ -272,19 +273,20 @@ def BaseClient(host, verify_ssl=None, api_version=None, username=None,
                password=None, auth_service_url="", api_timeout=None):
     if api_version == 1:
         return BaseClientV1(
-            host, verify_ssl=verify_ssl, username=username, password=password, api_timeout=api_timeout,
+            host, verify_ssl=verify_ssl, username=username, password=password,
+            api_timeout=api_timeout,
         )
     elif api_version == 2:
         return BaseClientV2(
-            host, verify_ssl=verify_ssl, username=username, password=password, api_timeout=api_timeout,
-            auth_service_url=auth_service_url,
+            host, verify_ssl=verify_ssl, username=username, password=password,
+            auth_service_url=auth_service_url, api_timeout=api_timeout,
         )
     elif api_version is None:
         # Try V2 first
         logger.debug("checking for v2 API")
         v2_client = BaseClientV2(
-            host, verify_ssl=verify_ssl, username=username, password=password, api_timeout=api_timeout,
-            auth_service_url=auth_service_url,
+            host, verify_ssl=verify_ssl, username=username, password=password,
+            auth_service_url=auth_service_url, api_timeout=api_timeout,
         )
         try:
             v2_client.check_status()


### PR DESCRIPTION
Today I faced problem, when thread became unaccessible because of long answer from Docker Hub registry. I think, all requests to remote APIs should have reasonable timeouts. For me - it's about 10 seconds. If API is not responding - I prefer to get exception and not wait for a lifetime. But Python Requests library has no timeout by default.

So I've added optional parameter, which can be used like:

```python
client = DockerRegistryClient('https://index.docker.io', api_version=1, api_timeout=10)
```

where `api_timeout` could be float or tuple according to [requests docs](http://docs.python-requests.org/en/master/user/quickstart/#timeouts).