### PR TITLE
add support to BaseClient for blob upload

### DIFF
--- a/docker_registry_client/_BaseClient.py
+++ b/docker_registry_client/_BaseClient.py
@@ -192,6 +192,11 @@ class BaseClientV2(CommonBaseClient):
         self.auth.desired_scope = 'registry:catalog:*'
         return self._http_call('/v2/_catalog', get)
 
+    def get_blob(self, name, digest):
+        self.auth.desired_scope = 'repository:%s:*' % name
+        return self._http_response(self.BLOB, get,
+                                   name=name, digest=digest)
+
     def get_repository_tags(self, name):
         self.auth.desired_scope = 'repository:%s:*' % name
         return self._http_call(self.LIST_TAGS, get, name=name)
@@ -200,11 +205,11 @@ class BaseClientV2(CommonBaseClient):
         m = self.get_manifest(name, reference)
         return m._content, m._digest
 
-    def get_manifest(self, name, reference):
+    def get_manifest(self, name, reference, schema=None):
         self.auth.desired_scope = 'repository:%s:*' % name
         response = self._http_response(
             self.MANIFEST, get, name=name, reference=reference,
-            schema=self.schema_1_signed,
+            schema=schema or self.schema_1_signed
         )
         self._cache_manifest_digest(name, reference, response=response)
         return _Manifest(

--- a/docker_registry_client/digest.py
+++ b/docker_registry_client/digest.py
@@ -1,0 +1,14 @@
+import hashlib
+
+
+def docker_digest(fpath=None, fobj=None, prepend=True):
+    if fobj is None:
+        fobj = open(fpath, 'rb')
+    hasher = hashlib.sha256()
+    for chunk in iter(lambda: fobj.read(8192), b''):
+        hasher.update(chunk)
+    fobj.seek(0)
+    retval = hasher.hexdigest()
+    if prepend:
+        retval = 'sha256:' + retval
+    return retval

--- a/tests/test_base_client.py
+++ b/tests/test_base_client.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
+from io import BytesIO
 
-from docker_registry_client._BaseClient import BaseClientV1, BaseClientV2
+from docker_registry_client._BaseClient import (
+    BaseClientV1, BaseClientV2, _Manifest
+)
 from drc_test_utils.mock_registry import (
     mock_v1_registry, mock_v2_registry, TEST_NAME, TEST_TAG,
 )
@@ -21,3 +24,14 @@ class TestBaseClientV2(object):
         url = mock_v2_registry()
         manifest, digest = BaseClientV2(url).get_manifest_and_digest(TEST_NAME,
                                                                      TEST_TAG)
+
+
+class TestManifest(object):
+    FAKE_MANIFEST = b'{ "schemaVersion": 2 }'
+    FAKE_DIGEST = ('sha256:0467ad45d6957ca671e3d219aa5965d4'
+                   '7f8621823a80c8e76174bcc1b9a225fd')
+
+    def test_fromfile(self):
+        fobj = BytesIO(self.FAKE_MANIFEST)
+        manifest = _Manifest.from_file(fobj=fobj)
+        assert manifest._digest == self.FAKE_DIGEST

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps =
     docker-py==1.10.6
     flexmock==0.10.2
     pytest==3.0.5
+    ecdsa==0.13
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
 * change BaseClientV2._http_response to accept bindata which is passed
directly to requests
 * add _Manifest.from_file to support loading a manifest from a file
then calling put_manifest
 * add BaseClientV2.put_blob based on implementation in python-dxf