### PR TITLE
Fix auth URL

### DIFF
--- a/docker-registry-show.py
+++ b/docker-registry-show.py
@@ -106,7 +106,8 @@ class CLI(object):
         if args.authorization_service:
             warnings.warn(
                 'The --authorization-service flag is deprecated; '
-                'use --authorization-service-url instead'
+                'use --authorization-service-url instead',
+                DeprecationWarning
             )
             kwargs.setdefault('auth_service_url_full',
                               urljoin(args.authorization_service, 'v2/token'))

--- a/docker-registry-show.py
+++ b/docker-registry-show.py
@@ -39,8 +39,14 @@ class CLI(object):
         self.parser.add_argument('--username', metavar='USERNAME')
         self.parser.add_argument('--password', metavar='PASSWORD')
 
-        self.parser.add_argument('--authorization-service', metavar='AUTH_SERVICE', type=str,
-                                 help='authorization service URL (including scheme) (for registry v2 only)')
+        self.parser.add_argument(
+            '--authorization-service-url', metavar='AUTH_SERVICE_URL', type=str,
+            help='complete authorization service URL including scheme (for registry v2 only)',
+        )
+        self.parser.add_argument(
+            '--authorization-service-name', metavar='AUTH_SERVICE_NAME', type=str,
+            help='authorization URL "service" parameter for custom auth services (v2 only)',
+        )
 
         self.parser.add_argument('registry', metavar='REGISTRY', nargs=1,
                                  help='registry URL (including scheme)')
@@ -71,7 +77,8 @@ class CLI(object):
             kwargs['api_version'] = args.api_version
 
         client = DockerRegistryClient(args.registry[0],
-                                      auth_service_url=args.authorization_service,
+                                      auth_service_url=args.authorization_service_url,
+                                      auth_service_name=args.authorization_service_name,
                                       verify_ssl=args.verify_ssl,
                                       **kwargs)
 

--- a/docker-registry-show.py
+++ b/docker-registry-show.py
@@ -18,18 +18,27 @@ limitations under the License.
 from __future__ import absolute_import
 
 import argparse
-from docker_registry_client import DockerRegistryClient
 import json
 import logging
+import warnings
+
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
+
+
 import requests
+
+from docker_registry_client import DockerRegistryClient
 
 
 class CLI(object):
     def __init__(self):
         self.parser = argparse.ArgumentParser()
-        excl_group = self.parser.add_mutually_exclusive_group()
-        excl_group.add_argument("-q", "--quiet", action="store_true")
-        excl_group.add_argument("-v", "--verbose", action="store_true")
+        verb_excl_group = self.parser.add_mutually_exclusive_group()
+        verb_excl_group.add_argument("-q", "--quiet", action="store_true")
+        verb_excl_group.add_argument("-v", "--verbose", action="store_true")
 
         self.parser.add_argument('--verify-ssl', dest='verify_ssl',
                                  action='store_true')
@@ -39,13 +48,29 @@ class CLI(object):
         self.parser.add_argument('--username', metavar='USERNAME')
         self.parser.add_argument('--password', metavar='PASSWORD')
 
-        self.parser.add_argument(
+        auth_excl_group = self.parser.add_mutually_exclusive_group()
+        auth_excl_group.add_argument(
             '--authorization-service-url', metavar='AUTH_SERVICE_URL', type=str,
-            help='complete authorization service URL including scheme (for registry v2 only)',
+            help=(
+                'auth service host URL with with scheme and path '
+                '[e.g. http://foo.com/v2/token] (v2 API only)'
+            ),
         )
+        # DEPRECATED old form of the argument that assumes a path for the URL
+        auth_excl_group.add_argument(
+            '--authorization-service', metavar='AUTH_SERVICE', type=str,
+            help=(
+                '[DEPRECATED] auth service host URL with scheme, without path '
+                '[e.g. http://foo.com] (v2 API only)'
+            ),
+        )
+
         self.parser.add_argument(
             '--authorization-service-name', metavar='AUTH_SERVICE_NAME', type=str,
-            help='authorization URL "service" parameter for custom auth services (v2 only)',
+            help=(
+                'auth service URL "service" query parameter for custom auth service names '
+                '[e.g. container_registry, for GitLab auth] (v2 API only)'
+            ),
         )
 
         self.parser.add_argument('registry', metavar='REGISTRY', nargs=1,
@@ -71,16 +96,25 @@ class CLI(object):
         kwargs = {
             'username': args.username,
             'password': args.password,
+            'verify_ssl': args.verify_ssl,
+            'auth_service_name': args.authorization_service_name,
+            'auth_service_url_full': args.authorization_service_url
         }
+
+        # Get the URL of the auth service from the command-line flags, accounting for the
+        # deprecated url flag; only use the deprecated one if the
+        if args.authorization_service:
+            warnings.warn(
+                'The --authorization-service flag is deprecated; '
+                'use --authorization-service-url instead'
+            )
+            kwargs.setdefault('auth_service_url_full',
+                              urljoin(args.authorization_service, 'v2/token'))
 
         if args.api_version:
             kwargs['api_version'] = args.api_version
 
-        client = DockerRegistryClient(args.registry[0],
-                                      auth_service_url=args.authorization_service_url,
-                                      auth_service_name=args.authorization_service_name,
-                                      verify_ssl=args.verify_ssl,
-                                      **kwargs)
+        client = DockerRegistryClient(args.registry[0], **kwargs)
 
         if args.repository:
             if args.ref:

--- a/docker_registry_client/AuthorizationService.py
+++ b/docker_registry_client/AuthorizationService.py
@@ -54,16 +54,18 @@ class AuthorizationService(object):
             self.token_required = False
 
     def get_new_token(self):
-        rsp = requests.get("%s?service=%s&scope=%s" %
-                           (self.url, self.service_name, self.desired_scope),
+        scope = '&scope={}'.format(self.desired_scope) if self.desired_scope else ''
+        rsp = requests.get("%s?service=%s%s" %
+                           (self.url, self.service_name, scope),
                            auth=self.auth, verify=self.verify,
                            timeout=self.api_timeout)
-        if not rsp.ok:
-            logger.error("Can't get token for authentication")
-            self.token = ""
-        else:
+        if rsp.ok:
             self.token = rsp.json()['token']
 
             # We managed to get a new token, update the current scope to the one we
             # wanted
             self.scope = self.desired_scope
+        else:
+            logger.error("Can't get token for authentication")
+            self.token = ""
+            self.scope = None

--- a/docker_registry_client/DockerRegistryClient.py
+++ b/docker_registry_client/DockerRegistryClient.py
@@ -6,7 +6,7 @@ from .Repository import Repository
 
 class DockerRegistryClient(object):
     def __init__(self, host, verify_ssl=None, api_version=None, username=None,
-                 password=None, auth_service_url="", api_timeout=None):
+                 password=None, auth_service_url="", auth_service_name=None, api_timeout=None):
         """
         Constructor
 
@@ -25,6 +25,7 @@ class DockerRegistryClient(object):
                                        api_version=api_version,
                                        username=username, password=password,
                                        auth_service_url=auth_service_url,
+                                       auth_service_name=auth_service_name,
                                        api_timeout=api_timeout)
         self.api_version = self._base_client.version
         self._repositories = {}

--- a/docker_registry_client/DockerRegistryClient.py
+++ b/docker_registry_client/DockerRegistryClient.py
@@ -5,19 +5,20 @@ from .Repository import Repository
 
 
 class DockerRegistryClient(object):
-    def __init__(self, host, verify_ssl=None, api_version=None, username=None,
-                 password=None, auth_service_url="", auth_service_name=None, api_timeout=None):
+    def __init__(self, host, verify_ssl=None, api_version=None, username=None, password=None,
+                 auth_service_url="", auth_service_url_full="", auth_service_name=None,
+                 api_timeout=None):
         """
         Constructor
 
         :param host: str, registry URL including scheme
         :param verify_ssl: bool, whether to verify SSL certificate
         :param api_version: int, API version to require
-        :param username: username to use for basic authentication when
-          connecting to the registry
+        :param username: username to use for basic authentication when connecting to the registry
         :param password: password to use for basic authentication
-        :param auth_service_url: authorization service URL (including scheme,
-          for v2 only)
+        :param auth_service_url_full: authorization service URL with scheme and path (v2),
+        :param auth_service_url: DEPRECATED authorization service URL with scheme but no path (v2)
+        :param auth_service_name: service name to use with auth services; defaults to registry host
         :param api_timeout: timeout for external request
         """
 
@@ -25,6 +26,7 @@ class DockerRegistryClient(object):
                                        api_version=api_version,
                                        username=username, password=password,
                                        auth_service_url=auth_service_url,
+                                       auth_service_url_full=auth_service_url_full,
                                        auth_service_name=auth_service_name,
                                        api_timeout=api_timeout)
         self.api_version = self._base_client.version

--- a/docker_registry_client/_BaseClient.py
+++ b/docker_registry_client/_BaseClient.py
@@ -181,7 +181,7 @@ class BaseClientV2(CommonBaseClient):
         return 2
 
     def check_status(self):
-        self.auth.desired_scope = 'registry:catalog:*'
+        self.auth.desired_scope = ''
         return self._http_call('/v2/', get)
 
     def catalog(self):

--- a/docker_registry_client/_BaseClient.py
+++ b/docker_registry_client/_BaseClient.py
@@ -165,7 +165,7 @@ class BaseClientV2(CommonBaseClient):
 
         # Default to the main part of the repository hostname if the service name is missing
         # or None (the default)
-        auth_service_name = kwargs.pop("auth_service_name") or urlsplit(host).netloc
+        auth_service_name = kwargs.pop("auth_service_name", "") or urlsplit(host).netloc
 
         # Get the URL of the auth service from the args, accounting for the deprecated url arg
         auth_service_url = kwargs.pop("auth_service_url_full", "")
@@ -189,7 +189,7 @@ class BaseClientV2(CommonBaseClient):
         # provided
         # See: http://docs.python-requests.org/en/master/user/quickstart/#custom-headers
         if auth_service_url:
-          auth = self.method_kwargs.pop('auth')
+          auth = self.method_kwargs.pop('auth', None)
         else:
           auth = self.method_kwargs.get('auth')
 

--- a/docker_registry_client/_BaseClient.py
+++ b/docker_registry_client/_BaseClient.py
@@ -1,21 +1,24 @@
 import logging
-from requests import get, put, delete
-from requests.exceptions import HTTPError
 import json
-from .AuthorizationService import AuthorizationService
-from .manifest import sign as sign_manifest
+import warnings
 
 try:
     from urllib.parse import urlsplit
 except ImportError:
     from urlparse import urlsplit
 
+from requests import get, put, delete
+from requests.exceptions import HTTPError
+
+from .AuthorizationService import AuthorizationService
+from .manifest import sign as sign_manifest
+
+
+# Module setup
 
 # urllib3 throws some ssl warnings with older versions of python
 #   they're probably ok for the registry client to ignore
-import warnings
-warnings.filterwarnings("ignore")
-
+warnings.filterwarnings("ignore", module="urllib3", append=True)
 
 logger = logging.getLogger(__name__)
 

--- a/docker_registry_client/_BaseClient.py
+++ b/docker_registry_client/_BaseClient.py
@@ -167,12 +167,25 @@ class BaseClientV2(CommonBaseClient):
 
         super(BaseClientV2, self).__init__(*args, **kwargs)
 
+        # If we are using token authentication with v2, we use the username
+        # and pw only for the authorization service and not for the registry
+        # itself.
+        #
+        # We must pop the auth kwarg so it does not get sent to requests,
+        # because override the authentication token if it sees the username/password
+        # provided
+        # See: http://docs.python-requests.org/en/master/user/quickstart/#custom-headers
+        if auth_service_url:
+          auth = self.method_kwargs.pop('auth')
+        else:
+          auth = self.method_kwargs.get('auth')
+
         self._manifest_digests = {}
         self.auth = AuthorizationService(
             service_name=auth_service_name,
             url=auth_service_url,
             verify=self.method_kwargs.get('verify', False),
-            auth=self.method_kwargs.get('auth', None),
+            auth=auth,
             api_timeout=self.method_kwargs.get('api_timeout')
         )
 

--- a/docker_registry_client/_BaseClient.py
+++ b/docker_registry_client/_BaseClient.py
@@ -173,7 +173,8 @@ class BaseClientV2(CommonBaseClient):
 
         if deprecated_auth_service_url_arg:
             warnings.warn(
-                'The auth_service_url argument is deprecated; use auth_service_url_full instead'
+                'The auth_service_url argument is deprecated; use auth_service_url_full instead',
+                DeprecationWarning,
             )
             if not auth_service_url:
               auth_service_url = urljoin(deprecated_auth_service_url_arg, 'v2/token')

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     ],
     keywords='docker docker-registry REST',
     packages=find_packages(),
+    scripts=['docker-registry-show.py'],
     install_requires=[
         'requests>=2.4.3, <3.0.0',
         'ecdsa>=0.13.0, <0.14.0',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,11 +16,11 @@ def docker_client():
 
 
 def wait_till_up(url, attempts):
-    for i in range(attempts-1):
+    for i in range(attempts - 1):
         try:
             requests.get(url)
             return
-        except exceptions.ConnectionError as e:
+        except exceptions.ConnectionError:
             time.sleep(0.1 * 2**i)
     else:
         requests.get(url)

--- a/tests/drc_test_utils/mock_registry.py
+++ b/tests/drc_test_utils/mock_registry.py
@@ -7,7 +7,7 @@ from requests.exceptions import HTTPError
 from requests.models import Response
 
 
-REGISTRY_URL = "https://registry.example.com:5000"
+REGISTRY_URL = "https://registry.example.com:5000/v2/token"
 TEST_NAMESPACE = 'library'
 TEST_REPO = 'myrepo'
 TEST_NAME = '%s/%s' % (TEST_NAMESPACE, TEST_REPO)

--- a/tests/drc_test_utils/mock_registry.py
+++ b/tests/drc_test_utils/mock_registry.py
@@ -7,7 +7,7 @@ from requests.exceptions import HTTPError
 from requests.models import Response
 
 
-REGISTRY_URL = "https://registry.example.com:5000/v2/token"
+REGISTRY_URL = "https://registry.example.com:5000/"
 TEST_NAMESPACE = 'library'
 TEST_REPO = 'myrepo'
 TEST_NAME = '%s/%s' % (TEST_NAMESPACE, TEST_REPO)

--- a/tests/integration/test_base_client.py
+++ b/tests/integration/test_base_client.py
@@ -38,12 +38,12 @@ def test_base_client_edit_manifest(docker_client, registry):
     pull = list(pull)
     tag = 'localhost:5000/x-drc-example:x-drc-test-put'
 
+    errors = [evt for evt in pull if 'error' in evt]
+    assert errors == []
+
     expected_statuses = {
         'Status: Downloaded newer image for ' + tag,
         'Status: Image is up to date for ' + tag,
     }
-
-    errors = [evt for evt in pull if 'error' in evt]
-    assert errors == []
 
     assert {evt.get('status') for evt in pull} & expected_statuses

--- a/tests/test_base_client.py
+++ b/tests/test_base_client.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import pytest
+
 from docker_registry_client._BaseClient import BaseClientV1, BaseClientV2
 from drc_test_utils.mock_registry import (
     mock_v1_registry, mock_v2_registry, TEST_NAME, TEST_TAG,
@@ -13,11 +15,22 @@ class TestBaseClientV1(object):
 
 
 class TestBaseClientV2(object):
+    def setup_method(self):
+        self.url = mock_v2_registry()
+
     def test_check_status(self):
-        url = mock_v2_registry()
-        BaseClientV2(url).check_status()
+        BaseClientV2(self.url).check_status()
 
     def test_get_manifest_and_digest(self):
-        url = mock_v2_registry()
-        manifest, digest = BaseClientV2(url).get_manifest_and_digest(TEST_NAME,
-                                                                     TEST_TAG)
+        manifest, digest = BaseClientV2(self.url).get_manifest_and_digest(TEST_NAME, TEST_TAG)
+
+    def test_deprecation_warnings(self):
+        with pytest.warns(DeprecationWarning):
+            BaseClientV2(self.url, auth_service_url='https://myhost.com')
+
+    def test_auth_url_defaults(self):
+        assert BaseClientV2(self.url, auth_service_url='https://myhost.com').auth.url \
+            == 'https://myhost.com/v2/token'
+
+        assert BaseClientV2(self.url, auth_service_url_full='https://myhost.com/foo').auth.url \
+            == 'https://myhost.com/foo'


### PR DESCRIPTION
The way that the auth url was being used by AuthorizationService was too restrictive
and made assumptions about the format of the URL that are not part of the standard and are violated by some existing authorization schemes: GitLab's authorization, for example, uses a different URL format (no `v2/token` path) and does not name the `service` GET parameter sent to the authorization URL with the same format as DockerHub does (it uses`container_registry`, instead of the registry host name).

The changes in this PR do two main things:
1. It adds a parameter to the client constructor, `auth_service_name`, which allows client consumer code to provide custom service names; if not provided, the code defaults to the previous behavior (using the registry hostname).
2. It adds a new auth service URL parameter `auth_service_url_full`. In this parameter, the `/v2/token` path is no longer automatically assumed on all URLs and must be provided explicitly if needed. **This new parameter deprecates the older `auth_service_url` parameter, which will now raise a `DeprecationWarning` if provided**.

As a minor additional improvement, the PR also makes the `docker-registry-show.py` script releasted to users' PATHs upon package installation (via the `scripts` argument in `setup.py`).