### PR TITLE
Add blob copy capability

### DIFF
--- a/docker-registry-show.py
+++ b/docker-registry-show.py
@@ -106,7 +106,8 @@ class CLI(object):
         if args.authorization_service:
             warnings.warn(
                 'The --authorization-service flag is deprecated; '
-                'use --authorization-service-url instead'
+                'use --authorization-service-url instead',
+                DeprecationWarning
             )
             kwargs.setdefault('auth_service_url_full',
                               urljoin(args.authorization_service, 'v2/token'))

--- a/docker-registry-show.py
+++ b/docker-registry-show.py
@@ -39,8 +39,14 @@ class CLI(object):
         self.parser.add_argument('--username', metavar='USERNAME')
         self.parser.add_argument('--password', metavar='PASSWORD')
 
-        self.parser.add_argument('--authorization-service', metavar='AUTH_SERVICE', type=str,
-                                 help='authorization service URL (including scheme) (for registry v2 only)')
+        self.parser.add_argument(
+            '--authorization-service-url', metavar='AUTH_SERVICE_URL', type=str,
+            help='complete authorization service URL including scheme (for registry v2 only)',
+        )
+        self.parser.add_argument(
+            '--authorization-service-name', metavar='AUTH_SERVICE_NAME', type=str,
+            help='authorization URL "service" parameter for custom auth services (v2 only)',
+        )
 
         self.parser.add_argument('registry', metavar='REGISTRY', nargs=1,
                                  help='registry URL (including scheme)')
@@ -71,7 +77,8 @@ class CLI(object):
             kwargs['api_version'] = args.api_version
 
         client = DockerRegistryClient(args.registry[0],
-                                      auth_service_url=args.authorization_service,
+                                      auth_service_url=args.authorization_service_url,
+                                      auth_service_name=args.authorization_service_name,
                                       verify_ssl=args.verify_ssl,
                                       **kwargs)
 

--- a/docker-registry-show.py
+++ b/docker-registry-show.py
@@ -18,18 +18,27 @@ limitations under the License.
 from __future__ import absolute_import
 
 import argparse
-from docker_registry_client import DockerRegistryClient
 import json
 import logging
+import warnings
+
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
+
+
 import requests
+
+from docker_registry_client import DockerRegistryClient
 
 
 class CLI(object):
     def __init__(self):
         self.parser = argparse.ArgumentParser()
-        excl_group = self.parser.add_mutually_exclusive_group()
-        excl_group.add_argument("-q", "--quiet", action="store_true")
-        excl_group.add_argument("-v", "--verbose", action="store_true")
+        verb_excl_group = self.parser.add_mutually_exclusive_group()
+        verb_excl_group.add_argument("-q", "--quiet", action="store_true")
+        verb_excl_group.add_argument("-v", "--verbose", action="store_true")
 
         self.parser.add_argument('--verify-ssl', dest='verify_ssl',
                                  action='store_true')
@@ -39,13 +48,29 @@ class CLI(object):
         self.parser.add_argument('--username', metavar='USERNAME')
         self.parser.add_argument('--password', metavar='PASSWORD')
 
-        self.parser.add_argument(
+        auth_excl_group = self.parser.add_mutually_exclusive_group()
+        auth_excl_group.add_argument(
             '--authorization-service-url', metavar='AUTH_SERVICE_URL', type=str,
-            help='complete authorization service URL including scheme (for registry v2 only)',
+            help=(
+                'auth service host URL with with scheme and path '
+                '[e.g. http://foo.com/v2/token] (v2 API only)'
+            ),
         )
+        # DEPRECATED old form of the argument that assumes a path for the URL
+        auth_excl_group.add_argument(
+            '--authorization-service', metavar='AUTH_SERVICE', type=str,
+            help=(
+                '[DEPRECATED] auth service host URL with scheme, without path '
+                '[e.g. http://foo.com] (v2 API only)'
+            ),
+        )
+
         self.parser.add_argument(
             '--authorization-service-name', metavar='AUTH_SERVICE_NAME', type=str,
-            help='authorization URL "service" parameter for custom auth services (v2 only)',
+            help=(
+                'auth service URL "service" query parameter for custom auth service names '
+                '[e.g. container_registry, for GitLab auth] (v2 API only)'
+            ),
         )
 
         self.parser.add_argument('registry', metavar='REGISTRY', nargs=1,
@@ -71,16 +96,25 @@ class CLI(object):
         kwargs = {
             'username': args.username,
             'password': args.password,
+            'verify_ssl': args.verify_ssl,
+            'auth_service_name': args.authorization_service_name,
+            'auth_service_url_full': args.authorization_service_url
         }
+
+        # Get the URL of the auth service from the command-line flags, accounting for the
+        # deprecated url flag; only use the deprecated one if the
+        if args.authorization_service:
+            warnings.warn(
+                'The --authorization-service flag is deprecated; '
+                'use --authorization-service-url instead'
+            )
+            kwargs.setdefault('auth_service_url_full',
+                              urljoin(args.authorization_service, 'v2/token'))
 
         if args.api_version:
             kwargs['api_version'] = args.api_version
 
-        client = DockerRegistryClient(args.registry[0],
-                                      auth_service_url=args.authorization_service_url,
-                                      auth_service_name=args.authorization_service_name,
-                                      verify_ssl=args.verify_ssl,
-                                      **kwargs)
+        client = DockerRegistryClient(args.registry[0], **kwargs)
 
         if args.repository:
             if args.ref:

--- a/docker_registry_client/AuthorizationService.py
+++ b/docker_registry_client/AuthorizationService.py
@@ -54,16 +54,18 @@ class AuthorizationService(object):
             self.token_required = False
 
     def get_new_token(self):
-        rsp = requests.get("%s?service=%s&scope=%s" %
-                           (self.url, self.service_name, self.desired_scope),
+        scope = '&scope={}'.format(self.desired_scope) if self.desired_scope else ''
+        rsp = requests.get("%s?service=%s%s" %
+                           (self.url, self.service_name, scope),
                            auth=self.auth, verify=self.verify,
                            timeout=self.api_timeout)
-        if not rsp.ok:
-            logger.error("Can't get token for authentication")
-            self.token = ""
-        else:
+        if rsp.ok:
             self.token = rsp.json()['token']
 
             # We managed to get a new token, update the current scope to the one we
             # wanted
             self.scope = self.desired_scope
+        else:
+            logger.error("Can't get token for authentication")
+            self.token = ""
+            self.scope = None

--- a/docker_registry_client/AuthorizationService.py
+++ b/docker_registry_client/AuthorizationService.py
@@ -57,7 +57,7 @@ class AuthorizationService(object):
         rsp = requests.get(
             self.url,
             params={
-                'service': self._service_name,
+                'service': self.service_name,
                 'scope': self.desired_scope,
             },
             auth=self.auth,

--- a/docker_registry_client/AuthorizationService.py
+++ b/docker_registry_client/AuthorizationService.py
@@ -54,11 +54,17 @@ class AuthorizationService(object):
             self.token_required = False
 
     def get_new_token(self):
-        scope = '&scope={}'.format(self.desired_scope) if self.desired_scope else ''
-        rsp = requests.get("%s?service=%s%s" %
-                           (self.url, self.service_name, scope),
-                           auth=self.auth, verify=self.verify,
-                           timeout=self.api_timeout)
+        rsp = requests.get(
+            self.url,
+            params={
+                'service': self._service_name,
+                'scope': self.desired_scope,
+            },
+            auth=self.auth,
+            verify=self.verify,
+            timeout=self.api_timeout
+        )
+
         if rsp.ok:
             self.token = rsp.json()['token']
 

--- a/docker_registry_client/DockerRegistryClient.py
+++ b/docker_registry_client/DockerRegistryClient.py
@@ -6,7 +6,7 @@ from .Repository import Repository
 
 class DockerRegistryClient(object):
     def __init__(self, host, verify_ssl=None, api_version=None, username=None,
-                 password=None, auth_service_url="", api_timeout=None):
+                 password=None, auth_service_url="", auth_service_name=None, api_timeout=None):
         """
         Constructor
 
@@ -25,6 +25,7 @@ class DockerRegistryClient(object):
                                        api_version=api_version,
                                        username=username, password=password,
                                        auth_service_url=auth_service_url,
+                                       auth_service_name=auth_service_name,
                                        api_timeout=api_timeout)
         self.api_version = self._base_client.version
         self._repositories = {}

--- a/docker_registry_client/DockerRegistryClient.py
+++ b/docker_registry_client/DockerRegistryClient.py
@@ -5,19 +5,20 @@ from .Repository import Repository
 
 
 class DockerRegistryClient(object):
-    def __init__(self, host, verify_ssl=None, api_version=None, username=None,
-                 password=None, auth_service_url="", auth_service_name=None, api_timeout=None):
+    def __init__(self, host, verify_ssl=None, api_version=None, username=None, password=None,
+                 auth_service_url="", auth_service_url_full="", auth_service_name=None,
+                 api_timeout=None):
         """
         Constructor
 
         :param host: str, registry URL including scheme
         :param verify_ssl: bool, whether to verify SSL certificate
         :param api_version: int, API version to require
-        :param username: username to use for basic authentication when
-          connecting to the registry
+        :param username: username to use for basic authentication when connecting to the registry
         :param password: password to use for basic authentication
-        :param auth_service_url: authorization service URL (including scheme,
-          for v2 only)
+        :param auth_service_url_full: authorization service URL with scheme and path (v2),
+        :param auth_service_url: DEPRECATED authorization service URL with scheme but no path (v2)
+        :param auth_service_name: service name to use with auth services; defaults to registry host
         :param api_timeout: timeout for external request
         """
 
@@ -25,6 +26,7 @@ class DockerRegistryClient(object):
                                        api_version=api_version,
                                        username=username, password=password,
                                        auth_service_url=auth_service_url,
+                                       auth_service_url_full=auth_service_url_full,
                                        auth_service_name=auth_service_name,
                                        api_timeout=api_timeout)
         self.api_version = self._base_client.version

--- a/docker_registry_client/_BaseClient.py
+++ b/docker_registry_client/_BaseClient.py
@@ -181,7 +181,7 @@ class BaseClientV2(CommonBaseClient):
         return 2
 
     def check_status(self):
-        self.auth.desired_scope = 'registry:catalog:*'
+        self.auth.desired_scope = ''
         return self._http_call('/v2/', get)
 
     def catalog(self):

--- a/docker_registry_client/_BaseClient.py
+++ b/docker_registry_client/_BaseClient.py
@@ -165,7 +165,7 @@ class BaseClientV2(CommonBaseClient):
 
         # Default to the main part of the repository hostname if the service name is missing
         # or None (the default)
-        auth_service_name = kwargs.pop("auth_service_name") or urlsplit(host).netloc
+        auth_service_name = kwargs.pop("auth_service_name", "") or urlsplit(host).netloc
 
         # Get the URL of the auth service from the args, accounting for the deprecated url arg
         auth_service_url = kwargs.pop("auth_service_url_full", "")
@@ -189,7 +189,7 @@ class BaseClientV2(CommonBaseClient):
         # provided
         # See: http://docs.python-requests.org/en/master/user/quickstart/#custom-headers
         if auth_service_url:
-          auth = self.method_kwargs.pop('auth')
+          auth = self.method_kwargs.pop('auth', None)
         else:
           auth = self.method_kwargs.get('auth')
 

--- a/docker_registry_client/_BaseClient.py
+++ b/docker_registry_client/_BaseClient.py
@@ -1,21 +1,24 @@
 import logging
-from requests import get, put, delete
-from requests.exceptions import HTTPError
 import json
-from .AuthorizationService import AuthorizationService
-from .manifest import sign as sign_manifest
+import warnings
 
 try:
     from urllib.parse import urlsplit
 except ImportError:
     from urlparse import urlsplit
 
+from requests import get, put, delete
+from requests.exceptions import HTTPError
+
+from .AuthorizationService import AuthorizationService
+from .manifest import sign as sign_manifest
+
+
+# Module setup
 
 # urllib3 throws some ssl warnings with older versions of python
 #   they're probably ok for the registry client to ignore
-import warnings
-warnings.filterwarnings("ignore")
-
+warnings.filterwarnings("ignore", module="urllib3", append=True)
 
 logger = logging.getLogger(__name__)
 

--- a/docker_registry_client/_BaseClient.py
+++ b/docker_registry_client/_BaseClient.py
@@ -167,12 +167,25 @@ class BaseClientV2(CommonBaseClient):
 
         super(BaseClientV2, self).__init__(*args, **kwargs)
 
+        # If we are using token authentication with v2, we use the username
+        # and pw only for the authorization service and not for the registry
+        # itself.
+        #
+        # We must pop the auth kwarg so it does not get sent to requests,
+        # because override the authentication token if it sees the username/password
+        # provided
+        # See: http://docs.python-requests.org/en/master/user/quickstart/#custom-headers
+        if auth_service_url:
+          auth = self.method_kwargs.pop('auth')
+        else:
+          auth = self.method_kwargs.get('auth')
+
         self._manifest_digests = {}
         self.auth = AuthorizationService(
             service_name=auth_service_name,
             url=auth_service_url,
             verify=self.method_kwargs.get('verify', False),
-            auth=self.method_kwargs.get('auth', None),
+            auth=auth,
             api_timeout=self.method_kwargs.get('api_timeout')
         )
 

--- a/docker_registry_client/_BaseClient.py
+++ b/docker_registry_client/_BaseClient.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     from urlparse import urljoin, urlsplit
 
-from requests import get, delete, post, put
+from requests import delete, get, head, post, put
 from requests.exceptions import HTTPError
 
 from .AuthorizationService import AuthorizationService
@@ -236,6 +236,15 @@ class BaseClientV2(CommonBaseClient):
             type=response.headers.get('Content-Type', 'application/json'),
             digest=self._manifest_digests[name, reference],
         )
+
+    def check_manifest(self, name, reference):
+        self.auth.desired_scope = 'repository:%s:*' % name
+        response = self._http_response(
+            self.MANIFEST, head, name=name, reference=reference,
+            schema=self.schema_1_signed,
+        )
+        self._cache_manifest_digest(name, reference, response=response)
+        return response.ok
 
     def put_manifest(self, name, reference, manifest):
         self.auth.desired_scope = 'repository:%s:*' % name

--- a/docker_registry_client/_BaseClient.py
+++ b/docker_registry_client/_BaseClient.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     from urlparse import urljoin, urlsplit
 
-from requests import get, put, delete
+from requests import get, delete, post, put
 from requests.exceptions import HTTPError
 
 from .AuthorizationService import AuthorizationService
@@ -156,6 +156,7 @@ class BaseClientV2(CommonBaseClient):
     LIST_TAGS = '/v2/{name}/tags/list'
     MANIFEST = '/v2/{name}/manifests/{reference}'
     BLOB = '/v2/{name}/blobs/{digest}'
+    BLOB_MOUNT = '/v2/{name}/blobs/uploads/?mount={digest}&from={origin}'
     schema_1_signed = BASE_CONTENT_TYPE + '.v1+prettyjws'
     schema_1 = BASE_CONTENT_TYPE + '.v1+json'
     schema_2 = BASE_CONTENT_TYPE + '.v2+json'
@@ -252,6 +253,11 @@ class BaseClientV2(CommonBaseClient):
         self.auth.desired_scope = 'repository:%s:*' % name
         return self._http_call(self.MANIFEST, delete,
                                name=name, reference=digest)
+
+    def copy_blob(self, origin, digest, destination):
+        self.auth.desired_scope = ['repository:%s:*' % repo for repo in (origin, destination)]
+        return self._http_call(self.BLOB_MOUNT, post,
+                               name=destination, digest=digest, origin=origin)
 
     def delete_blob(self, name, digest):
         self.auth.desired_scope = 'repository:%s:*' % name

--- a/docker_registry_client/_BaseClient.py
+++ b/docker_registry_client/_BaseClient.py
@@ -178,7 +178,7 @@ class BaseClientV2(CommonBaseClient):
                 DeprecationWarning,
             )
             if not auth_service_url:
-              auth_service_url = urljoin(deprecated_auth_service_url_arg, 'v2/token')
+                auth_service_url = urljoin(deprecated_auth_service_url_arg, 'v2/token')
 
         super(BaseClientV2, self).__init__(*args, **kwargs)
 
@@ -191,9 +191,9 @@ class BaseClientV2(CommonBaseClient):
         # provided
         # See: http://docs.python-requests.org/en/master/user/quickstart/#custom-headers
         if auth_service_url:
-          auth = self.method_kwargs.pop('auth', None)
+            auth = self.method_kwargs.pop('auth', None)
         else:
-          auth = self.method_kwargs.get('auth')
+            auth = self.method_kwargs.get('auth')
 
         self._manifest_digests = {}
         self.auth = AuthorizationService(

--- a/docker_registry_client/_BaseClient.py
+++ b/docker_registry_client/_BaseClient.py
@@ -1,5 +1,5 @@
-import logging
 import json
+import logging
 import warnings
 
 try:
@@ -250,7 +250,12 @@ class BaseClientV2(CommonBaseClient):
         self.auth.desired_scope = 'repository:%s:*' % name
         content = {}
         content.update(manifest._content)
-        content.update({'name': name, 'tag': reference})
+
+        content['name'] = name
+
+        # If reference is a tag, update it; otherwise, leave the tag as is
+        if not reference.startswith('sha256:'):
+            content['tag'] = reference
 
         return self._http_call(
             self.MANIFEST, put, data=sign_manifest(content),

--- a/docker_registry_client/_BaseClient.py
+++ b/docker_registry_client/_BaseClient.py
@@ -319,7 +319,13 @@ class BaseClientV2(CommonBaseClient):
         response = method(self.host + path,
                           data=data, headers=header, **self.method_kwargs)
         logger.debug("%s %s", response.status_code, response.reason)
-        response.raise_for_status()
+
+        try:
+            response.raise_for_status()
+        except HTTPError as e:
+            if e.response.content:
+                logger.error('Error Response: {}'.format(response.content))
+            raise
 
         return response
 

--- a/docker_registry_client/_BaseClient.py
+++ b/docker_registry_client/_BaseClient.py
@@ -173,7 +173,8 @@ class BaseClientV2(CommonBaseClient):
 
         if deprecated_auth_service_url_arg:
             warnings.warn(
-                'The auth_service_url argument is deprecated; use auth_service_url_full instead'
+                'The auth_service_url argument is deprecated; use auth_service_url_full instead',
+                DeprecationWarning,
             )
             if not auth_service_url:
               auth_service_url = urljoin(deprecated_auth_service_url_arg, 'v2/token')

--- a/docker_registry_client/manifest.py
+++ b/docker_registry_client/manifest.py
@@ -1,6 +1,7 @@
 # Extracted from python-dxf (https://git.io/vM0EB) used under license (MIT).
 import base64
 import ecdsa
+import hashlib
 import jws
 import json
 
@@ -89,3 +90,17 @@ def sign(manifest, key=None):
         json.dumps(signatures) +
         format_tail
     )
+
+
+def digest(manifest):
+    # For manifests, the digest is the manifest body without the signature content, also known as
+    # the JWS payload - https://docs.docker.com/registry/spec/api/#content-digests
+    m = assign({}, manifest)
+
+    try:
+        del m['signatures']
+    except KeyError:
+        pass
+
+    manifest_json = json.dumps(m, sort_keys=True)
+    return 'sha256:{}'.format(hashlib.sha256(manifest_json.encode('utf-8')).hexdigest())

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     ],
     keywords='docker docker-registry REST',
     packages=find_packages(),
+    scripts=['docker-registry-show.py'],
     install_requires=[
         'requests>=2.4.3, <3.0.0',
         'ecdsa>=0.13.0, <0.14.0',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,10 @@ def registry(docker_client):
                 5000: 5000,
             },
         ),
+        # Have to explicitly enable support for v1 schemas on recent versions of registry
+        environment={
+          'REGISTRY_COMPATIBILITY_SCHEMA1': '{ "enabled": true }',
+        },
     )
     try:
         cli.start(cont)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,11 +16,11 @@ def docker_client():
 
 
 def wait_till_up(url, attempts):
-    for i in range(attempts-1):
+    for i in range(attempts - 1):
         try:
             requests.get(url)
             return
-        except exceptions.ConnectionError as e:
+        except exceptions.ConnectionError:
             time.sleep(0.1 * 2**i)
     else:
         requests.get(url)

--- a/tests/drc_test_utils/mock_registry.py
+++ b/tests/drc_test_utils/mock_registry.py
@@ -7,7 +7,7 @@ from requests.exceptions import HTTPError
 from requests.models import Response
 
 
-REGISTRY_URL = "https://registry.example.com:5000"
+REGISTRY_URL = "https://registry.example.com:5000/v2/token"
 TEST_NAMESPACE = 'library'
 TEST_REPO = 'myrepo'
 TEST_NAME = '%s/%s' % (TEST_NAMESPACE, TEST_REPO)

--- a/tests/drc_test_utils/mock_registry.py
+++ b/tests/drc_test_utils/mock_registry.py
@@ -7,7 +7,7 @@ from requests.exceptions import HTTPError
 from requests.models import Response
 
 
-REGISTRY_URL = "https://registry.example.com:5000/v2/token"
+REGISTRY_URL = "https://registry.example.com:5000/"
 TEST_NAMESPACE = 'library'
 TEST_REPO = 'myrepo'
 TEST_NAME = '%s/%s' % (TEST_NAMESPACE, TEST_REPO)

--- a/tests/drc_test_utils/mock_registry.py
+++ b/tests/drc_test_utils/mock_registry.py
@@ -10,7 +10,9 @@ from requests.models import Response
 REGISTRY_URL = "https://registry.example.com:5000/"
 TEST_NAMESPACE = 'library'
 TEST_REPO = 'myrepo'
+TEST_REPO2 = 'myotherrepo'
 TEST_NAME = '%s/%s' % (TEST_NAMESPACE, TEST_REPO)
+TEST_NAME2 = '%s/%s' % (TEST_NAMESPACE, TEST_REPO2)
 TEST_TAG = 'latest'
 TEST_MANIFEST_DIGEST = '''\
 sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b'''
@@ -51,6 +53,8 @@ class MockRegistry(object):
         return s.format(namespace=TEST_NAMESPACE,
                         repo=TEST_REPO,
                         name=TEST_NAME,
+                        repo2=TEST_REPO2,
+                        name2=TEST_NAME2,
                         tag=TEST_TAG,
                         digest=TEST_MANIFEST_DIGEST)
 
@@ -64,6 +68,9 @@ class MockRegistry(object):
 
     def get(self, *args, **kwargs):
         return self.call(self.GET_MAP, *args, **kwargs)
+
+    def post(self, *args, **kwargs):
+        return self.call(self.POST_MAP, *args, **kwargs)
 
     def delete(self, *args, **kwargs):
         return self.call(self.DELETE_MAP, *args, **kwargs)
@@ -96,6 +103,7 @@ class MockV2Registry(MockRegistry):
     TAGS_LIBRARY = MockRegistry.format('/v2/{repo}/tags/list')
     MANIFEST_TAG = MockRegistry.format('/v2/{name}/manifests/{tag}')
     MANIFEST_DIGEST = MockRegistry.format('/v2/{name}/manifests/{digest}')
+    BLOB_MOUNT = MockRegistry.format('/v2/{name2}/blobs/uploads/?mount={digest}&from={name}')
 
     GET_MAP = {
         '/v2/': MockResponse(200),
@@ -126,12 +134,18 @@ class MockV2Registry(MockRegistry):
         MANIFEST_DIGEST: MockResponse(202, data={}),
     }
 
+    POST_MAP = {
+        BLOB_MOUNT: MockResponse(201, data={}),
+    }
+
 
 def mock_v2_registry():
     v2_registry = MockV2Registry()
     flexmock(_BaseClient,
              get=v2_registry.get,
-             delete=v2_registry.delete)
+             delete=v2_registry.delete,
+             post=v2_registry.post)
+
     return REGISTRY_URL
 
 

--- a/tests/integration/test_base_client.py
+++ b/tests/integration/test_base_client.py
@@ -38,12 +38,12 @@ def test_base_client_edit_manifest(docker_client, registry):
     pull = list(pull)
     tag = 'localhost:5000/x-drc-example:x-drc-test-put'
 
+    errors = [evt for evt in pull if 'error' in evt]
+    assert errors == []
+
     expected_statuses = {
         'Status: Downloaded newer image for ' + tag,
         'Status: Image is up to date for ' + tag,
     }
-
-    errors = [evt for evt in pull if 'error' in evt]
-    assert errors == []
 
     assert {evt.get('status') for evt in pull} & expected_statuses

--- a/tests/test_base_client.py
+++ b/tests/test_base_client.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import pytest
+
 from docker_registry_client._BaseClient import BaseClientV1, BaseClientV2
 from drc_test_utils.mock_registry import (
     mock_v1_registry, mock_v2_registry, TEST_NAME, TEST_TAG,
@@ -13,11 +15,22 @@ class TestBaseClientV1(object):
 
 
 class TestBaseClientV2(object):
+    def setup_method(self):
+        self.url = mock_v2_registry()
+
     def test_check_status(self):
-        url = mock_v2_registry()
-        BaseClientV2(url).check_status()
+        BaseClientV2(self.url).check_status()
 
     def test_get_manifest_and_digest(self):
-        url = mock_v2_registry()
-        manifest, digest = BaseClientV2(url).get_manifest_and_digest(TEST_NAME,
-                                                                     TEST_TAG)
+        manifest, digest = BaseClientV2(self.url).get_manifest_and_digest(TEST_NAME, TEST_TAG)
+
+    def test_deprecation_warnings(self):
+        with pytest.warns(DeprecationWarning):
+            BaseClientV2(self.url, auth_service_url='https://myhost.com')
+
+    def test_auth_url_defaults(self):
+        assert BaseClientV2(self.url, auth_service_url='https://myhost.com').auth.url \
+            == 'https://myhost.com/v2/token'
+
+        assert BaseClientV2(self.url, auth_service_url_full='https://myhost.com/foo').auth.url \
+            == 'https://myhost.com/foo'

--- a/tests/test_base_client.py
+++ b/tests/test_base_client.py
@@ -4,7 +4,8 @@ import pytest
 
 from docker_registry_client._BaseClient import BaseClientV1, BaseClientV2
 from drc_test_utils.mock_registry import (
-    mock_v1_registry, mock_v2_registry, TEST_NAME, TEST_TAG,
+    mock_v1_registry, mock_v2_registry,
+    TEST_MANIFEST_DIGEST, TEST_NAME, TEST_NAME2, TEST_TAG,
 )
 
 
@@ -34,3 +35,6 @@ class TestBaseClientV2(object):
 
         assert BaseClientV2(self.url, auth_service_url_full='https://myhost.com/foo').auth.url \
             == 'https://myhost.com/foo'
+
+    def test_copy_blob(self):
+        BaseClientV2(self.url).copy_blob(TEST_NAME, TEST_MANIFEST_DIGEST, TEST_NAME2)


### PR DESCRIPTION
Meant to be merged in after #53.

This PR adds a method to the V2 BaseClient: `copy_blob`. The method takes advantage of the Registry API's [cross-repository blob mount](https://docs.docker.com/registry/spec/api/#cross-repository-blob-mount) feature to copy blobs that already exist in the registry from one repo to another without actually downloading and re-uploading them.

A unit test is included.

Other minor changes in this PR:
- add a `check_manifest` method to test for the existence of a manifest
- resolve the unit tests failing with HTTP 500 codes on `put_manifest` (Root cause was a Docker Registry config issue in testing)
- clean up a minor issue conflating tags and references in `put_manifest`: now consumers can put manifests using their digest as a reference without updating the tag to be the same as the digest (which was the former, erroneous behavior)
- add a manifest digestion utility function (`manifest.digest`) to enable users to PUT manifests by digest.