### PR TITLE
Explicitly use v2 scheme for v2 registry

### DIFF
--- a/docker_registry_client/_BaseClient.py
+++ b/docker_registry_client/_BaseClient.py
@@ -187,7 +187,7 @@ class BaseClientV2(CommonBaseClient):
         self.auth.desired_scope = 'repository:%s:*' % name
         response = self._http_response(
             self.MANIFEST, get, name=name, reference=reference,
-            schema=self.schema_1_signed,
+            schema=self.schema_2
         )
         self._cache_manifest_digest(name, reference, response=response)
         return _Manifest(


### PR DESCRIPTION
Currently v2 registries uses v2+json header, otherwise one will get
wrong digest returned. To ensure proper usage, explicitly set scheme v2.